### PR TITLE
Fix jOOQ compilation with GraalVM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.version>2.5.1.Final</quarkus.version>
-        <org.jooq.version>3.15.5</org.jooq.version>
+        <org.jooq.version>3.15.12</org.jooq.version>
     </properties>
 
     <scm>

--- a/runtime/src/main/java/io/quarkiverse/jooq/runtime/graal/PostgreSQLNotPresent.java
+++ b/runtime/src/main/java/io/quarkiverse/jooq/runtime/graal/PostgreSQLNotPresent.java
@@ -1,0 +1,15 @@
+package io.quarkiverse.jooq.runtime.graal;
+
+import java.util.function.BooleanSupplier;
+
+public class PostgreSQLNotPresent implements BooleanSupplier {
+    @Override
+    public boolean getAsBoolean() {
+        try {
+            Class.forName("org.postgresql.util.PGInterval");
+            return false;
+        } catch (ClassNotFoundException e) {
+            return true;
+        }
+    }
+}

--- a/runtime/src/main/java/io/quarkiverse/jooq/runtime/graal/PostgresUtilsSubstitutions.java
+++ b/runtime/src/main/java/io/quarkiverse/jooq/runtime/graal/PostgresUtilsSubstitutions.java
@@ -1,0 +1,48 @@
+package io.quarkiverse.jooq.runtime.graal;
+
+import org.jooq.types.DayToSecond;
+import org.jooq.types.YearToMonth;
+import org.jooq.types.YearToSecond;
+
+import com.oracle.svm.core.annotate.Substitute;
+import com.oracle.svm.core.annotate.TargetClass;
+
+@TargetClass(className = "org.jooq.util.postgres.PostgresUtils", onlyWith = PostgreSQLNotPresent.class)
+public final class PostgresUtilsSubstitutions {
+
+    @Substitute
+    public static DayToSecond toDayToSecond(Object pgInterval) {
+        throw new IllegalArgumentException(
+                "Unsupported interval type. Make sure you have the pgjdbc or redshift driver on your classpath: " + pgInterval);
+    }
+
+    @Substitute
+    public static YearToMonth toYearToMonth(Object pgInterval) {
+        throw new IllegalArgumentException(
+                "Unsupported interval type. Make sure you have the pgjdbc or redshift driver on your classpath: " + pgInterval);
+    }
+
+    @Substitute
+    public static Object toPGInterval(DayToSecond interval) {
+        throw new IllegalArgumentException(
+                "Unsupported interval type. Make sure you have the pgjdbc or redshift driver on your classpath: " + interval);
+
+    }
+
+    @Substitute
+    public static Object toPGInterval(YearToSecond interval) {
+        throw new IllegalArgumentException(
+                "Unsupported interval type. Make sure you have the pgjdbc or redshift driver on your classpath: " + interval);
+    }
+
+    @Substitute
+    public static Object toPGInterval(YearToMonth interval) {
+        throw new IllegalArgumentException(
+                "Unsupported interval type. Make sure you have the pgjdbc or redshift driver on your classpath: " + interval);
+    }
+
+    @Substitute
+    private static final boolean pgIntervalAvailable() {
+        return false;
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/quarkiverse/quarkus-jooq/issues/73
Bumps jOOQ to 3.15.12 (didn't bump to 3.16 because it will require Jakarta to properly work)
Adds GraalVM substitutions to remove references to postgresql lib if the lib is not found in the classpath