### PR TITLE
Use `graal-sdk` instead of `svm`

### DIFF
--- a/quarkus-jooq-pro/runtime/pom.xml
+++ b/quarkus-jooq-pro/runtime/pom.xml
@@ -27,8 +27,8 @@
             <artifactId>quarkus-arc</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
-            <artifactId>svm</artifactId>
+            <groupId>org.graalvm.sdk</groupId>
+            <artifactId>graal-sdk</artifactId>
         </dependency>
 
         <!-- jOOQ dependencies -->

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -26,8 +26,8 @@
             <artifactId>quarkus-arc</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
-            <artifactId>svm</artifactId>
+            <groupId>org.graalvm.sdk</groupId>
+            <artifactId>graal-sdk</artifactId>
         </dependency>
 
         <!-- jOOQ dependencies -->


### PR DESCRIPTION
- Caused by https://github.com/quarkusio/quarkus/pull/34145