### PR TITLE
Upgrade Quarkus from 3.15.3 to 3.34.3

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/jooq/deployment/JooqProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/jooq/deployment/JooqProcessor.java
@@ -72,7 +72,8 @@ public class JooqProcessor {
                 .getKnownClasses()
                 .stream()
                 .filter(o -> jooqDBReflectClasses.matcher(o.name().toString()).matches())
-                .forEach(clazz -> reflectiveClass.produce(new ReflectiveClassBuildItem(true, true, clazz.name().toString())));
+                .forEach(clazz -> reflectiveClass.produce(
+                        ReflectiveClassBuildItem.builder(clazz.name().toString()).methods().fields().build()));
     }
 
     @SuppressWarnings("unchecked")
@@ -89,8 +90,8 @@ public class JooqProcessor {
             return;
         }
 
-        reflectiveClass.produce(new ReflectiveClassBuildItem(true, false, AbstractDslContextProducer.class));
-        reflectiveClass.produce(new ReflectiveClassBuildItem(false, true, LoggerListener.class));
+        reflectiveClass.produce(ReflectiveClassBuildItem.builder(AbstractDslContextProducer.class).methods().build());
+        reflectiveClass.produce(ReflectiveClassBuildItem.builder(LoggerListener.class).fields().build());
 
         if (!isPresentDialect(jooqConfig.defaultConfig())) {
             log.warn("No default sql-dialect been defined");

--- a/docs/modules/ROOT/pages/includes/quarkus-jooq.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-jooq.adoc
@@ -1,4 +1,3 @@
-:summaryTableId: quarkus-jooq_quarkus-jooq
 [.configuration-legend]
 icon:lock[title=Fixed at build time] Configuration property fixed at build time - All other configuration properties are overridable at runtime
 [.configuration-reference.searchable, cols="80,.^10,.^10"]
@@ -8,7 +7,11 @@ h|[.header-title]##Configuration property##
 h|Type
 h|Default
 
-a|icon:lock[title=Fixed at build time] [[quarkus-jooq_quarkus-jooq-dialect]] [.property-path]##link:#quarkus-jooq_quarkus-jooq-dialect[`quarkus.jooq.dialect`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-jooq_quarkus-jooq-dialect]] [.property-path]##link:#quarkus-jooq_quarkus-jooq-dialect[`+++quarkus.jooq.dialect+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.jooq.dialect+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
@@ -25,7 +28,11 @@ endif::add-copy-button-to-env-var[]
 |string
 |required icon:exclamation-circle[title=Configuration property is required]
 
-a|icon:lock[title=Fixed at build time] [[quarkus-jooq_quarkus-jooq-datasource]] [.property-path]##link:#quarkus-jooq_quarkus-jooq-datasource[`quarkus.jooq.datasource`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-jooq_quarkus-jooq-datasource]] [.property-path]##link:#quarkus-jooq_quarkus-jooq-datasource[`+++quarkus.jooq.datasource+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.jooq.datasource+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
@@ -42,7 +49,11 @@ endif::add-copy-button-to-env-var[]
 |string
 |
 
-a|icon:lock[title=Fixed at build time] [[quarkus-jooq_quarkus-jooq-configuration]] [.property-path]##link:#quarkus-jooq_quarkus-jooq-configuration[`quarkus.jooq.configuration`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-jooq_quarkus-jooq-configuration]] [.property-path]##link:#quarkus-jooq_quarkus-jooq-configuration[`+++quarkus.jooq.configuration+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.jooq.configuration+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
@@ -59,7 +70,11 @@ endif::add-copy-button-to-env-var[]
 |string
 |
 
-a|icon:lock[title=Fixed at build time] [[quarkus-jooq_quarkus-jooq-configuration-inject]] [.property-path]##link:#quarkus-jooq_quarkus-jooq-configuration-inject[`quarkus.jooq.configuration-inject`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-jooq_quarkus-jooq-configuration-inject]] [.property-path]##link:#quarkus-jooq_quarkus-jooq-configuration-inject[`+++quarkus.jooq.configuration-inject+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.jooq.configuration-inject+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
@@ -76,7 +91,11 @@ endif::add-copy-button-to-env-var[]
 |string
 |
 
-a|icon:lock[title=Fixed at build time] [[quarkus-jooq_quarkus-jooq-register-generated-classes-for-reflection]] [.property-path]##link:#quarkus-jooq_quarkus-jooq-register-generated-classes-for-reflection[`quarkus.jooq.register-generated-classes-for-reflection`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-jooq_quarkus-jooq-register-generated-classes-for-reflection]] [.property-path]##link:#quarkus-jooq_quarkus-jooq-register-generated-classes-for-reflection[`+++quarkus.jooq.register-generated-classes-for-reflection+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.jooq.register-generated-classes-for-reflection+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
@@ -91,9 +110,13 @@ Environment variable: `+++QUARKUS_JOOQ_REGISTER_GENERATED_CLASSES_FOR_REFLECTION
 endif::add-copy-button-to-env-var[]
 --
 |boolean
-|`true`
+|`+++true+++`
 
-a|icon:lock[title=Fixed at build time] [[quarkus-jooq_quarkus-jooq-generated-classes-pattern]] [.property-path]##link:#quarkus-jooq_quarkus-jooq-generated-classes-pattern[`quarkus.jooq.generated-classes-pattern`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-jooq_quarkus-jooq-generated-classes-pattern]] [.property-path]##link:#quarkus-jooq_quarkus-jooq-generated-classes-pattern[`+++quarkus.jooq.generated-classes-pattern+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.jooq.generated-classes-pattern+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
@@ -108,9 +131,13 @@ Environment variable: `+++QUARKUS_JOOQ_GENERATED_CLASSES_PATTERN+++`
 endif::add-copy-button-to-env-var[]
 --
 |string
-|`.+\.tables\.(pojos\|records)\..+`
+|`+++.+\.tables\.(pojos\|records)\..++++`
 
-a|icon:lock[title=Fixed at build time] [[quarkus-jooq_quarkus-jooq-named-config-dialect]] [.property-path]##link:#quarkus-jooq_quarkus-jooq-named-config-dialect[`quarkus.jooq."named-config".dialect`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-jooq_quarkus-jooq-named-config-dialect]] [.property-path]##link:#quarkus-jooq_quarkus-jooq-named-config-dialect[`+++quarkus.jooq."named-config".dialect+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.jooq."named-config".dialect+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
@@ -127,7 +154,11 @@ endif::add-copy-button-to-env-var[]
 |string
 |required icon:exclamation-circle[title=Configuration property is required]
 
-a|icon:lock[title=Fixed at build time] [[quarkus-jooq_quarkus-jooq-named-config-datasource]] [.property-path]##link:#quarkus-jooq_quarkus-jooq-named-config-datasource[`quarkus.jooq."named-config".datasource`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-jooq_quarkus-jooq-named-config-datasource]] [.property-path]##link:#quarkus-jooq_quarkus-jooq-named-config-datasource[`+++quarkus.jooq."named-config".datasource+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.jooq."named-config".datasource+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
@@ -144,7 +175,11 @@ endif::add-copy-button-to-env-var[]
 |string
 |
 
-a|icon:lock[title=Fixed at build time] [[quarkus-jooq_quarkus-jooq-named-config-configuration]] [.property-path]##link:#quarkus-jooq_quarkus-jooq-named-config-configuration[`quarkus.jooq."named-config".configuration`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-jooq_quarkus-jooq-named-config-configuration]] [.property-path]##link:#quarkus-jooq_quarkus-jooq-named-config-configuration[`+++quarkus.jooq."named-config".configuration+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.jooq."named-config".configuration+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
@@ -161,7 +196,11 @@ endif::add-copy-button-to-env-var[]
 |string
 |
 
-a|icon:lock[title=Fixed at build time] [[quarkus-jooq_quarkus-jooq-named-config-configuration-inject]] [.property-path]##link:#quarkus-jooq_quarkus-jooq-named-config-configuration-inject[`quarkus.jooq."named-config".configuration-inject`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-jooq_quarkus-jooq-named-config-configuration-inject]] [.property-path]##link:#quarkus-jooq_quarkus-jooq-named-config-configuration-inject[`+++quarkus.jooq."named-config".configuration-inject+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.jooq."named-config".configuration-inject+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
@@ -180,5 +219,3 @@ endif::add-copy-button-to-env-var[]
 
 |===
 
-
-:!summaryTableId:

--- a/docs/modules/ROOT/pages/includes/quarkus-jooq_quarkus.jooq.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-jooq_quarkus.jooq.adoc
@@ -1,4 +1,3 @@
-:summaryTableId: quarkus-jooq_quarkus-jooq
 [.configuration-legend]
 icon:lock[title=Fixed at build time] Configuration property fixed at build time - All other configuration properties are overridable at runtime
 [.configuration-reference.searchable, cols="80,.^10,.^10"]
@@ -8,7 +7,11 @@ h|[.header-title]##Configuration property##
 h|Type
 h|Default
 
-a|icon:lock[title=Fixed at build time] [[quarkus-jooq_quarkus-jooq-dialect]] [.property-path]##link:#quarkus-jooq_quarkus-jooq-dialect[`quarkus.jooq.dialect`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-jooq_quarkus-jooq-dialect]] [.property-path]##link:#quarkus-jooq_quarkus-jooq-dialect[`+++quarkus.jooq.dialect+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.jooq.dialect+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
@@ -25,7 +28,11 @@ endif::add-copy-button-to-env-var[]
 |string
 |required icon:exclamation-circle[title=Configuration property is required]
 
-a|icon:lock[title=Fixed at build time] [[quarkus-jooq_quarkus-jooq-datasource]] [.property-path]##link:#quarkus-jooq_quarkus-jooq-datasource[`quarkus.jooq.datasource`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-jooq_quarkus-jooq-datasource]] [.property-path]##link:#quarkus-jooq_quarkus-jooq-datasource[`+++quarkus.jooq.datasource+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.jooq.datasource+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
@@ -42,7 +49,11 @@ endif::add-copy-button-to-env-var[]
 |string
 |
 
-a|icon:lock[title=Fixed at build time] [[quarkus-jooq_quarkus-jooq-configuration]] [.property-path]##link:#quarkus-jooq_quarkus-jooq-configuration[`quarkus.jooq.configuration`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-jooq_quarkus-jooq-configuration]] [.property-path]##link:#quarkus-jooq_quarkus-jooq-configuration[`+++quarkus.jooq.configuration+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.jooq.configuration+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
@@ -59,7 +70,11 @@ endif::add-copy-button-to-env-var[]
 |string
 |
 
-a|icon:lock[title=Fixed at build time] [[quarkus-jooq_quarkus-jooq-configuration-inject]] [.property-path]##link:#quarkus-jooq_quarkus-jooq-configuration-inject[`quarkus.jooq.configuration-inject`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-jooq_quarkus-jooq-configuration-inject]] [.property-path]##link:#quarkus-jooq_quarkus-jooq-configuration-inject[`+++quarkus.jooq.configuration-inject+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.jooq.configuration-inject+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
@@ -76,7 +91,11 @@ endif::add-copy-button-to-env-var[]
 |string
 |
 
-a|icon:lock[title=Fixed at build time] [[quarkus-jooq_quarkus-jooq-register-generated-classes-for-reflection]] [.property-path]##link:#quarkus-jooq_quarkus-jooq-register-generated-classes-for-reflection[`quarkus.jooq.register-generated-classes-for-reflection`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-jooq_quarkus-jooq-register-generated-classes-for-reflection]] [.property-path]##link:#quarkus-jooq_quarkus-jooq-register-generated-classes-for-reflection[`+++quarkus.jooq.register-generated-classes-for-reflection+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.jooq.register-generated-classes-for-reflection+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
@@ -91,9 +110,13 @@ Environment variable: `+++QUARKUS_JOOQ_REGISTER_GENERATED_CLASSES_FOR_REFLECTION
 endif::add-copy-button-to-env-var[]
 --
 |boolean
-|`true`
+|`+++true+++`
 
-a|icon:lock[title=Fixed at build time] [[quarkus-jooq_quarkus-jooq-generated-classes-pattern]] [.property-path]##link:#quarkus-jooq_quarkus-jooq-generated-classes-pattern[`quarkus.jooq.generated-classes-pattern`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-jooq_quarkus-jooq-generated-classes-pattern]] [.property-path]##link:#quarkus-jooq_quarkus-jooq-generated-classes-pattern[`+++quarkus.jooq.generated-classes-pattern+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.jooq.generated-classes-pattern+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
@@ -108,9 +131,13 @@ Environment variable: `+++QUARKUS_JOOQ_GENERATED_CLASSES_PATTERN+++`
 endif::add-copy-button-to-env-var[]
 --
 |string
-|`.+\.tables\.(pojos\|records)\..+`
+|`+++.+\.tables\.(pojos\|records)\..++++`
 
-a|icon:lock[title=Fixed at build time] [[quarkus-jooq_quarkus-jooq-named-config-dialect]] [.property-path]##link:#quarkus-jooq_quarkus-jooq-named-config-dialect[`quarkus.jooq."named-config".dialect`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-jooq_quarkus-jooq-named-config-dialect]] [.property-path]##link:#quarkus-jooq_quarkus-jooq-named-config-dialect[`+++quarkus.jooq."named-config".dialect+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.jooq."named-config".dialect+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
@@ -127,7 +154,11 @@ endif::add-copy-button-to-env-var[]
 |string
 |required icon:exclamation-circle[title=Configuration property is required]
 
-a|icon:lock[title=Fixed at build time] [[quarkus-jooq_quarkus-jooq-named-config-datasource]] [.property-path]##link:#quarkus-jooq_quarkus-jooq-named-config-datasource[`quarkus.jooq."named-config".datasource`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-jooq_quarkus-jooq-named-config-datasource]] [.property-path]##link:#quarkus-jooq_quarkus-jooq-named-config-datasource[`+++quarkus.jooq."named-config".datasource+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.jooq."named-config".datasource+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
@@ -144,7 +175,11 @@ endif::add-copy-button-to-env-var[]
 |string
 |
 
-a|icon:lock[title=Fixed at build time] [[quarkus-jooq_quarkus-jooq-named-config-configuration]] [.property-path]##link:#quarkus-jooq_quarkus-jooq-named-config-configuration[`quarkus.jooq."named-config".configuration`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-jooq_quarkus-jooq-named-config-configuration]] [.property-path]##link:#quarkus-jooq_quarkus-jooq-named-config-configuration[`+++quarkus.jooq."named-config".configuration+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.jooq."named-config".configuration+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
@@ -161,7 +196,11 @@ endif::add-copy-button-to-env-var[]
 |string
 |
 
-a|icon:lock[title=Fixed at build time] [[quarkus-jooq_quarkus-jooq-named-config-configuration-inject]] [.property-path]##link:#quarkus-jooq_quarkus-jooq-named-config-configuration-inject[`quarkus.jooq."named-config".configuration-inject`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-jooq_quarkus-jooq-named-config-configuration-inject]] [.property-path]##link:#quarkus-jooq_quarkus-jooq-named-config-configuration-inject[`+++quarkus.jooq."named-config".configuration-inject+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.jooq."named-config".configuration-inject+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
@@ -180,5 +219,3 @@ endif::add-copy-button-to-env-var[]
 
 |===
 
-
-:!summaryTableId:

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-        <quarkus.version>3.15.3</quarkus.version>
+        <quarkus.version>3.34.3</quarkus.version>
         <org.jooq.version>3.20.3</org.jooq.version>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -18,8 +18,8 @@
     <properties>
         <compiler-plugin.version>3.14.0</compiler-plugin.version>
         <maven.compiler.parameters>true</maven.compiler.parameters>
-        <maven.compiler.source>21</maven.compiler.source>
-        <maven.compiler.target>21</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 

--- a/pom.xml
+++ b/pom.xml
@@ -18,8 +18,8 @@
     <properties>
         <compiler-plugin.version>3.14.0</compiler-plugin.version>
         <maven.compiler.parameters>true</maven.compiler.parameters>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 

--- a/quarkus-jooq-pro/deployment/src/main/java/io/quarkiverse/jooq/pro/deployment/JooqProProcessor.java
+++ b/quarkus-jooq-pro/deployment/src/main/java/io/quarkiverse/jooq/pro/deployment/JooqProProcessor.java
@@ -39,8 +39,8 @@ class JooqProProcessor extends JooqProcessor {
             return;
         }
 
-        reflectiveClass.produce(new ReflectiveClassBuildItem(true, false, AbstractDslContextProducer.class));
-        reflectiveClass.produce(new ReflectiveClassBuildItem(false, true, LoggerListener.class));
+        reflectiveClass.produce(ReflectiveClassBuildItem.builder(AbstractDslContextProducer.class).methods().build());
+        reflectiveClass.produce(ReflectiveClassBuildItem.builder(LoggerListener.class).fields().build());
 
         if (!isPresentDialect(jooqConfig.defaultConfig())) {
             log.warn("No default sql-dialect been defined");


### PR DESCRIPTION
## Upgrade Quarkus from 3.15.3 to 3.34.3                                                                                                                                     
                                         
  ### Summary                                                                                                                                                                                             
                                                                                                                                                                                                          
  - Upgraded Quarkus from `3.15.3` to `3.34.3`                                                                                                                                                            
  - Migrated deprecated `ReflectiveClassBuildItem` constructor usages to the new builder API in `JooqProcessor` and `JooqProProcessor`                                                                    
  - Regenerated documentation to reflect Quarkus 3.34.3 config property format (copy button macros, formatting updates)
                                                                                                                                                                                                          
  ### Changes                                               
                                                                                                                                                                                                          
  | Module | Details |                                      
  |---|---|
  | `pom.xml` | Quarkus `3.15.3` → `3.34.3` |
  | `deployment/JooqProcessor.java` | Replaced deprecated `new ReflectiveClassBuildItem(...)` with `ReflectiveClassBuildItem.builder(...).methods().fields().build()` |                                   
  | `quarkus-jooq-pro/deployment/JooqProProcessor.java` | Same builder API migration |                                                                                                                    
  | `docs/modules/ROOT/pages/includes/` | Regenerated config docs for Quarkus 3.34.3 |                                                                                                                    
                                                                                                                                                                                                          
  ### Testing                                               
                                                                                                                                                                                                          
  - `mvn clean install` passes with 0 failures              
  - Integration tests run successfully against H2 in TCP mode